### PR TITLE
update Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,19 @@ Guidelines for any code contributions:
   4. Please squash all commits for a change into a single commit (this can be done using `git rebase -i`). Do your best to have a [well-formed commit message][] for the change.
   5. Remember not to add sensitive/confidential data such as hard-coded passwords, client information, email addresses etc.
   6. Remove legacy code (and tests) where possible to keep the codebase clean.
+  7. Any contribution does not contain, nor is it accompanied by:
+   - materials not created by you, or source code or other materials which result in the inclusion of third party materials;
+   - materials that would be considered confidential and/or proprietary information, or trade secrets owned by you or third parties;
+   - your, our, or a third party’s, internal data, whether or not considered confidential and/or proprietary, e.g., intranet URLs, internal emails, client information or references to the foregoing;
+   - materials which practice, or require the practice of, a patent owned or controlled by a third party, or a proprietary standard, specification, protocol, algorithm, or the like;
+   - software or other materials which are known to be the subject of an actual or threatened patent infringement or other legal claim;
+   - software which may be subject to export control laws or regulations;
+   - trademarks, or software which generates trademarks;
+   - nonpublic personal information, or personally identifying information generally (e.g. employee names), or information regulated or controlled by data privacy laws and regulations;
+   - product code names, roadmaps, future product descriptions;
+   - disparaging comments;
+   - viruses or other malicious components (including “back doors”, “time bombs”, “logic bombs”, “Trojan horses”, “worms”, “drop dead devices”, “viruses”, “trap doors”, “timers”, “clocks”, “counters” or similar), or any other computer software routine intended or designed to disable, damage, erase, disrupt or impair the normal operation of, or provide unauthorized access to, computer systems or any software or information stored on those computer systems;
+   - SSH private keys or passwords, or authentication means generally;
 
 Merging pull requests
 ---------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Guidelines for any code contributions:
   4. Please squash all commits for a change into a single commit (this can be done using `git rebase -i`). Do your best to have a [well-formed commit message][] for the change.
   5. Remember not to add sensitive/confidential data such as hard-coded passwords, client information, email addresses etc.
   6. Remove legacy code (and tests) where possible to keep the codebase clean.
-  7. Any contribution does not contain, nor is it accompanied by:
+  7. Any contribution must not contain, nor must be accompanied by:
    - materials not created by you, or source code or other materials which result in the inclusion of third party materials;
    - materials that would be considered confidential and/or proprietary information, or trade secrets owned by you or third parties;
    - your, our, or a third party’s, internal data, whether or not considered confidential and/or proprietary, e.g., intranet URLs, internal emails, client information or references to the foregoing;


### PR DESCRIPTION
Moved detailed list of unacceptable contributions from CLA to contribution guidelines.
Better have it at hand at each contribution as a checklist, instead of having a too heavy CLA, that you read only once.